### PR TITLE
feat: Add component separate tracking

### DIFF
--- a/src/lib/splitTesting.js
+++ b/src/lib/splitTesting.js
@@ -1,5 +1,6 @@
 import { BROWSER } from 'esm-env'
 import { v4 as uuidv4 } from 'uuid'
+import { prng_alea as seedrandom } from 'esm-seedrandom'
 
 const oneYear = 365 * 864e5
 
@@ -67,7 +68,66 @@ function clientGetSplitTestCookie(cookieName) {
 
   return document.cookie?.split(';').reduce((r, v) => {
     const [name, value] = v?.split('=').map(item => item.trim())
-    console.log(name, value)
     return name === cookieName ? decodeURIComponent(value) : r.trim()
   }, '')
+}
+
+/**
+ * Generate a random number based on a seed, meaning it will always be
+ * the same outcome as long as the identifier is the same..
+ * The key is also included to prevent one user from always seeing test A
+ * for every test case.
+ * @param {object} options - Optional parameters.
+ * @param {string} options.key - Key used to identify the current test
+ * @param {string[]} options.variants - Array of strings with all possible variants
+ * @param {string} options.identifier - Identifier used to find the current variants. Either from cookie or from user identifier.
+ * @param {string} options.force - Force a particular split test by string.
+ * @returns {string} The variant to be used
+ */
+export function getVariant({ key, variants = [], identifier, force }) {
+  const randomized = seedrandom(identifier + key).quick()
+  const index = Math.floor(randomized * variants.length)
+  return force && variants.includes(force) ? force : variants[index]
+}
+
+/**
+ * Perform a split test outside of a component. The variant is generated and returned from this function. It will perform a view action when called.
+ * @param {object} options - Optional parameters.
+ * @param {string} options.key - Key used to identify the current test
+ * @param {string} options.action - Action send to analytics tracking
+ * @param {string[]} options.variants - Array of strings with all possible variants
+ * @param {string|null} options.userIdentifier - Optional user identifier to override the cookie identifier
+ * @param {string} options.force - Force a particular split test by string.
+ * @param {Function} options.trackingFunction - Function to override the default GTM data layer tracking. `{ action, key, variant }` is passed as the first and only parameter.
+ * @returns {string} The variant that was used
+ * @example `
+ * const variant = performSplitTestAction({ ... })
+ * if (variant === "A") doThingA()
+ * else if (variant === "B") doThingB()
+ */
+export function performSplitTestAction({ key = '', action = 'view', variants = [], userIdentifier = null, force = null, trackingFunction = null } = {}) {
+  if (!BROWSER) return
+
+  const identifier = clientGetSplitTestIdentifier({ userIdentifier })
+  const variant = getVariant({ key, variants, identifier, force })
+
+  typeof trackingFunction === "function" ? trackingFunction({ action, key, variant }) : sendToDataLayer({ action, key, variant })
+
+  return variant
+}
+
+/**
+ * Send an event to GTM data layer
+ * @param {object} options - Parameters.
+ * @param {string} options.action - Action send to analytics tracking
+ * @param {string} options.key - Key used to identify the current test
+ * @param {string} options.variant - The current variant being used
+ * @example `
+ * const variant = performSplitTestAction({ ... })
+ * if (variant === "A") doThingA()
+ * else if (variant === "B") doThingB()
+ */
+export function sendToDataLayer({ action, key, variant } = {}) {
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push({ event: 'Split Test', action, label: key, value: variant })
 }

--- a/src/lib/splitTesting.js
+++ b/src/lib/splitTesting.js
@@ -74,7 +74,7 @@ function clientGetSplitTestCookie(cookieName) {
 
 /**
  * Generate a random number based on a seed, meaning it will always be
- * the same outcome as long as the identifier is the same..
+ * the same outcome as long as the identifier is the same.
  * The key is also included to prevent one user from always seeing test A
  * for every test case.
  * @param {object} options - Optional parameters.

--- a/src/lib/splitTesting.js
+++ b/src/lib/splitTesting.js
@@ -106,8 +106,6 @@ export function getVariant({ key, variants = [], identifier, force }) {
  * else if (variant === "B") doThingB()
  */
 export function performSplitTestAction({ key = '', action = 'view', variants = [], userIdentifier = null, force = null, trackingFunction = null } = {}) {
-  if (!BROWSER) return
-
   const identifier = clientGetSplitTestIdentifier({ userIdentifier })
   const variant = getVariant({ key, variants, identifier, force })
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,12 +1,24 @@
 <script>
   import { page } from '$app/stores'
   import SplitTest from '$lib/SplitTest.svelte'
+  import { performSplitTestAction } from '$lib/splitTesting.js'
 
   const colors = {
     Pink: '#d453f7',
     Blue: '#55cbf2',
     Yellow: '#f7c74e',
     Green: '#409b83',
+  }
+
+  function outsideOfComponent() {
+    const force = new URLSearchParams(window.location.search).get('force-split-test')
+    const variant = performSplitTestAction({
+      key: 'Some test key',
+      action: 'click',
+      variants: ['A', 'B'],
+      force,
+      trackingFunction: ({ variant }) => alert(`Performed action for variant "${variant}"`)
+    })
   }
 </script>
 
@@ -513,6 +525,33 @@ export async function load(&#123; <mark>data</mark> &#125;) &#123;
   </div>
 
   <div class="block">
+    <h3>Outside of components</h3>
+
+    <p>In some cases you might want to perform split tests outside of a component, perhaps right inside a javascript file. In that case you can use the <code>performSplitTestAction</code> function.</p>
+
+    <p>This function will return the current variant. It will perform an action when called, sending it to GTM by default.</p>
+
+    <code class="well"
+      ><pre>
+const variant = <mark>performSplitTestAction</mark>(&#123;
+  key: <mark class="string">'Some test key'</mark>,
+  action: <mark class="string">'click'</mark>,
+  variants: [<mark class="string">'A'</mark>, <mark class="string">'B'</mark>],
+  force,
+  trackingFunction: (&#123; variant &#125;) =>
+    alert(`Performed action for variant <mark class="string">"$&#123;variant&#125;"</mark>`)
+&#125;)
+
+if (variant === <mark class="string">"A"</mark>) doThingA()
+else if (variant === <mark class="string">"B"</mark>) doThingB()
+</pre></code>
+
+    <p>
+      <button class="button" on:click={outsideOfComponent}>Perform action outside of component</button>
+    </p>
+  </div>
+
+  <div class="block">
     <h2>Properties</h2>
 
     <p>This is a list of all configurable properties for each component and function.</p>
@@ -576,6 +615,20 @@ export async function load(&#123; <mark>data</mark> &#125;) &#123;
       </div>
       <code>options.cookieName</code> <code>'splitTestIdentifier'</code>
       <div>The name of the cookie used to store the split testing identifier.</div>
+    </div>
+
+    <h4>performSplitTestAction</h4>
+
+    <div class="table">
+      <strong>Property</strong> <strong>Default</strong> <strong>Description</strong>
+
+      <code>options</code> <code>null</code> <div>Optional parameters</div>
+      <code>options.key</code> <code>''</code> <div>Key used to identify the current test</div>
+      <code>options.action</code> <code>'view'</code> <div>Action send to analytics tracking</div>
+      <code>options.variants</code> <code>[]</code> <div>Array of strings with all possible variants</div>
+      <code>options.userIdentifier</code> <code>null</code> <div>Optional user identifier to override the cookie identifier</div>
+      <code>options.force</code> <code>null</code> <div>Force a particular split test by string.</div>
+      <code>options.trackingFunction</code> <code>null</code> <div>Function to override the default GTM data layer tracking. <code>&#123; action, key, variant &#125;</code> is passed as the first and only parameter.</div>
     </div>
   </div>
 

--- a/src/test/splitTesting.test.js
+++ b/src/test/splitTesting.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { performSplitTestAction } from '../lib/splitTesting.js'
+
+describe('splitTesting.js', () => {
+  describe('performSplitTestAction', () => {
+    it('Should return the expected variant', () => {
+      expect(performSplitTestAction({ key: 'A', variants: ['Variant A', 'Variant B'] })).toBe('Variant A')
+    })
+
+    it('Should return the forced variant regardless of key', () => {
+      expect(performSplitTestAction({ key: 'A', variants: ['Variant A', 'Variant B'], force: 'Variant B' })).toBe('Variant B')
+    })
+
+    it('Should call the given function', () => {
+      const mock = vi.fn()
+      performSplitTestAction({ trackingFunction: mock })
+      expect(mock).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a function that allows us to perform split tests outside of components. This can be handy if you want to test the results of a particular function. For example you could think of testing the results of showing a modal or redirecting someone to a page.

With this I've moved many shared functions from the component to the utils functions, cleaning up the component a little bit.

I've also added tests and docs for this new function.