### PR TITLE
chore: Add wrangler.toml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@sveltejs/adapter-auto": "^3.0.0",
 				"@sveltejs/adapter-cloudflare": "^4.8.0",
 				"@sveltejs/kit": "^2.5.27",
+				"@sveltejs/package": "^2.3.7",
 				"@sveltejs/vite-plugin-svelte": "^4.0.0",
 				"@testing-library/svelte": "^5.2.6",
 				"@types/eslint": "^9.6.0",
@@ -1230,9 +1231,9 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-cloudflare": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-cloudflare/-/adapter-cloudflare-4.8.0.tgz",
-			"integrity": "sha512-stt72ZXDmRoLBqqj2fAdMXyOZ0vDUoAiNe/GRKkfxb1wW5Smp/jBGhKVBwhlAIi7aeE0xEMehN1SBxId9QMh5g==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-cloudflare/-/adapter-cloudflare-4.9.0.tgz",
+			"integrity": "sha512-o7o8wXy5zDsEuE9oPWSHO5tAuPEulZZg2QavFdc00fcIHh1dxgCyIRZa5LPjAE8EcdJOh+8SFkhFgVRdCfOBvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1707,6 +1708,29 @@
 				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
 				"vite": "^5.0.3 || ^6.0.0"
+			}
+		},
+		"node_modules/@sveltejs/package": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-2.3.7.tgz",
+			"integrity": "sha512-LYgUkde5GUYqOpXbcoCGUpEH4Ctl3Wj4u4CVZBl56dEeLW5fGHE037ZL1qlK0Ky+QD5uUfwONSeGwIOIighFMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chokidar": "^4.0.0",
+				"kleur": "^4.1.5",
+				"sade": "^1.8.1",
+				"semver": "^7.5.4",
+				"svelte2tsx": "~0.7.16"
+			},
+			"bin": {
+				"svelte-package": "svelte-package.js"
+			},
+			"engines": {
+				"node": "^16.14 || >=18"
+			},
+			"peerDependencies": {
+				"svelte": "^3.44.0 || ^4.0.0 || ^5.0.0-next.1"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
@@ -2421,6 +2445,13 @@
 			"version": "10.4.3",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
 			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/dedent-js": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
+			"integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3521,6 +3552,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/lz-string": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -3683,6 +3724,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/no-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/node-forge": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -3835,6 +3887,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/path-exists": {
@@ -4667,6 +4730,21 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/svelte2tsx": {
+			"version": "0.7.31",
+			"resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.31.tgz",
+			"integrity": "sha512-exrN1o9mdCLAA7hTCudz731FIxomH/0SN9ZIX+WrY/XnlLuno/NNC1PF6JXPZVqp/4sMMDKteqyKoG44hliljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dedent-js": "^1.0.1",
+				"pascal-case": "^3.1.1"
+			},
+			"peerDependencies": {
+				"svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",
+				"typescript": "^4.9.4 || ^5.0.0"
+			}
+		},
 		"node_modules/symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -4773,8 +4851,7 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
 	"name": "svelte-split-testing",
 	"version": "2.0.0",
 	"engines": {
-    "node": "20 || >=22"
-  },
+		"node": "20 || >=22"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",
@@ -29,15 +29,16 @@
 		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/adapter-cloudflare": "^4.8.0",
 		"@sveltejs/kit": "^2.5.27",
+		"@sveltejs/package": "^2.3.7",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0",
-		"@types/eslint": "^9.6.0",
 		"@testing-library/svelte": "^5.2.6",
-		"esm-seedrandom": "^3.0.5",
+		"@types/eslint": "^9.6.0",
 		"eslint": "^9.7.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.45.1",
-		"jsdom": "^22.1.0",
+		"esm-seedrandom": "^3.0.5",
 		"globals": "^15.0.0",
+		"jsdom": "^22.1.0",
 		"prettier": "^3.3.2",
 		"prettier-plugin-svelte": "^3.2.6",
 		"publint": "^0.1.9",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+[dev]
+port = 5173
+local_protocol = "http"
+upstream_protocol = "https"
+
+[build]
+command = "npm ci && npm run build"


### PR DESCRIPTION
Previously the default (not having a file), was enough, but it seems that default now has deprecated options that no longer work.

Additionally I updated package.json. Really the only change here is re-adding `@sveltejs/package`, which is needed to publish the package but was removed by mistake. The other changes in this file are just ordering changes.